### PR TITLE
Add a switch for fullscreen smoothing and ability to select pixel size in windowed mode

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -156,6 +156,7 @@ int main(int argc, char *argv[]) {
   SelectRes select_res(&font_mono);
   const Resolution* resolution = select_res.Run();
   bool fullscreen = select_res.FullScreen();
+  bool smoothingEnabled = select_res.SmoothingEnabled();
   if (resolution == nullptr) {
     return 0;
   }
@@ -193,7 +194,7 @@ int main(int argc, char *argv[]) {
   sf::RenderTexture renderTexture;
   if (fullscreen) {
     renderTexture.create(resolution->width, resolution->height, settings);
-    renderTexture.setSmooth(true);
+    renderTexture.setSmooth(smoothingEnabled);
     renderTexture.setActive(true);
     window.setActive(false);
   }

--- a/src/SelectRes.cpp
+++ b/src/SelectRes.cpp
@@ -35,7 +35,7 @@ SelectRes::SelectRes(const sf::Font* _font) : font(_font), is_fullscreen(false) 
 int SelectRes::Select(const sf::Vector2i& mouse_pos) {
   const int select_ix = (mouse_pos.y + 25) / 60 - 2;
   const int select_bounds = (mouse_pos.y + 25) % 60;
-  if (select_ix < 0 || select_ix > num_resolutions) {
+  if (select_ix < 0 || select_ix > num_resolutions + 1) {
     return -1;
   }
   if (select_bounds > 42) {
@@ -56,7 +56,10 @@ void SelectRes::Draw(sf::RenderWindow& window, const sf::Vector2i& mouse_pos) {
     window.draw(MakeText(res_str.c_str(), 390.0f, y, 42, is_sel, false));
   }
   const char* ftxt = (is_fullscreen ? "Full Screen [X]" : "Full Screen [ ]");
-  window.draw(MakeText(ftxt, 320.0f, 530.0f, 40, sel_ix == num_resolutions));
+  window.draw(MakeText(ftxt, 320.0f, 525.0f, 40, sel_ix == num_resolutions));
+
+  const char* smtxt = (is_smoothingEnabled ? "Full Screen smoothing [X]" : "Full Screen smoothing [ ]");
+  window.draw(MakeText(smtxt, 320.0f, 585.0f, 40, sel_ix == num_resolutions + 1));
 }
 
 sf::Text SelectRes::MakeText(const char* str, float x, float y, int size, bool selected, bool centered) const {
@@ -76,7 +79,7 @@ sf::Text SelectRes::MakeText(const char* str, float x, float y, int size, bool s
 
 const Resolution* SelectRes::Run() {
   //Create the window
-  sf::VideoMode window_size(640, 600, 24);
+  sf::VideoMode window_size(640, 640, 24);
   sf::RenderWindow window(window_size, "Marble Marcher", sf::Style::Close);
   window.setVerticalSyncEnabled(true);
   window.requestFocus();
@@ -105,6 +108,8 @@ const Resolution* SelectRes::Run() {
           window.close();
         } else if (sel_ix == num_resolutions) {
           is_fullscreen = !is_fullscreen;
+        } else if (sel_ix == num_resolutions + 1) {
+          is_smoothingEnabled = !is_smoothingEnabled;
         }
       } else if (event.type == sf::Event::MouseButtonReleased) {
         mouse_pos = sf::Vector2i(event.mouseButton.x, event.mouseButton.y);

--- a/src/SelectRes.h
+++ b/src/SelectRes.h
@@ -32,6 +32,7 @@ public:
   SelectRes(const sf::Font* _font);
 
   bool FullScreen() const { return is_fullscreen; }
+  bool SmoothingEnabled() const { return is_smoothingEnabled; }
 
   int Select(const sf::Vector2i& mouse_pos);
   void Draw(sf::RenderWindow& window, const sf::Vector2i& mouse_pos);
@@ -42,6 +43,7 @@ private:
   const sf::Font* font;
 
   bool is_fullscreen;
+  bool is_smoothingEnabled = true;
 
   sf::Sound sound_hover;
   sf::SoundBuffer buff_hover;


### PR DESCRIPTION
When using fullscreen on lower resolutions, the image looks way too blurry (may be subjective). Hence a switch to choose between smoothed and crisp upscaling could be useful. Comparison for potato quality (1366x768 native resolution):
![lvl1_nosmooth](https://user-images.githubusercontent.com/46608177/51060141-afb18000-15ff-11e9-9764-7505aa1c5042.png)
![lvl1_smooth](https://user-images.githubusercontent.com/46608177/51060142-afb18000-15ff-11e9-80c2-83941ee4be3d.png)