### PR TITLE
2 game modifiers: Moon_gravity and scale_marble.

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -277,7 +277,7 @@ int main(int argc, char *argv[]) {
             if (selected == Overlays::PLAY) {
               game_mode = PLAYING;
               menu_music.stop();
-              scene.StartNewGame();
+              scene.StartNewGame(overlays.getMoonGravity(), overlays.getScaleMarble());
               scene.GetCurMusic().setVolume(GetVol());
               scene.GetCurMusic().play();
               LockMouse(window);
@@ -292,6 +292,10 @@ int main(int argc, char *argv[]) {
             } else if (selected == Overlays::EXIT) {
               window.close();
               break;
+            } else if (selected == Overlays::Overlays::TOGGLE_SCALE_MARBLE) {
+              overlays.toggleScaleMarble();
+            } else if (selected == Overlays::TOGGLE_MOON_GRAVITY) {
+              overlays.toggleMoonGravity();
             }
           } else if (game_mode == CONTROLS) {
             const Overlays::Texts selected = overlays.GetOption(Overlays::BACK, Overlays::BACK);
@@ -308,7 +312,7 @@ int main(int argc, char *argv[]) {
                 game_mode = PLAYING;
                 menu_music.stop();
                 scene.SetExposure(1.0f);
-                scene.StartSingle(selected - Overlays::L0);
+                scene.StartSingle(selected - Overlays::L0, overlays.getMoonGravity(), overlays.getScaleMarble());
                 scene.GetCurMusic().setVolume(GetVol());
                 scene.GetCurMusic().play();
                 LockMouse(window);

--- a/src/Overlays.cpp
+++ b/src/Overlays.cpp
@@ -70,7 +70,7 @@ void Overlays::UpdateMenu(float mouse_x, float mouse_y) {
 
   bool hasCompletedAll = true;
   for (int i = 0; i < num_levels; ++i) {
-    if (!high_scores.Has(i)) {
+    if (!high_scores.HasCompleted(i)) {
       hasCompletedAll = false;
       break;
     }

--- a/src/Overlays.cpp
+++ b/src/Overlays.cpp
@@ -53,6 +53,9 @@ Overlays::Texts Overlays::GetOption(Texts from, Texts to) {
   return Texts::TITLE;
 }
 
+bool toggle_scale_marble = false;
+bool toggle_moon_gravity = false;
+
 void Overlays::UpdateMenu(float mouse_x, float mouse_y) {
   //Update text boxes
   MakeText("Marble\nMarcher", 60, 20, 72, sf::Color::White, all_text[TITLE]);
@@ -64,6 +67,19 @@ void Overlays::UpdateMenu(float mouse_x, float mouse_y) {
   MakeText("\xA9""2019 CodeParade\nMusic by PettyTheft", 16, 652, 32, sf::Color::White, all_text[CREDITS], true);
   all_text[TITLE].setLineSpacing(0.76f);
   all_text[CREDITS].setLineSpacing(0.9f);
+
+  bool hasCompletedAll = true;
+  for (int i = 0; i < num_levels; ++i) {
+    if (!high_scores.Has(i)) {
+      hasCompletedAll = false;
+      break;
+    }
+  }
+
+  if (hasCompletedAll) {
+    MakeText(toggle_scale_marble ? "[X] Scroll scales marble" : "[ ] Scroll scales marble", 680, 590, 30, sf::Color::White, all_text[TOGGLE_SCALE_MARBLE], true);
+    MakeText(toggle_moon_gravity ? "[X] Moon Gravity" : "[ ] Moon Gravity", 680, 640, 30, sf::Color::White, all_text[TOGGLE_MOON_GRAVITY], true);
+  }
 
   //Check if mouse intersects anything
   UpdateHover(PLAY, EXIT, mouse_x, mouse_y);
@@ -287,4 +303,19 @@ void Overlays::UpdateHover(Texts from, Texts to, float mouse_x, float mouse_y) {
       all_hover[i] = false;
     }
   }
+}
+
+void Overlays::toggleScaleMarble() {
+  toggle_scale_marble = !toggle_scale_marble;
+}
+
+void Overlays::toggleMoonGravity() {
+  toggle_moon_gravity = !toggle_moon_gravity;
+}
+
+bool Overlays::getMoonGravity() {
+  return toggle_moon_gravity;
+}
+bool Overlays::getScaleMarble() {
+  return toggle_scale_marble;
 }

--- a/src/Overlays.h
+++ b/src/Overlays.h
@@ -29,6 +29,8 @@ public:
     LEVELS,
     CONTROLS,
     SCREEN_SAVER,
+    TOGGLE_MOON_GRAVITY,
+    TOGGLE_SCALE_MARBLE,
     EXIT,
     CREDITS,
     PAUSED,
@@ -68,6 +70,11 @@ public:
   void DrawArrow(sf::RenderWindow& window, const sf::Vector3f& v3);
   void DrawCredits(sf::RenderWindow& window);
   void DrawLevels(sf::RenderWindow& window);
+
+  void toggleScaleMarble();
+  void toggleMoonGravity();
+  bool getMoonGravity();
+  bool getScaleMarble();
 
 protected:
   void MakeText(const char* str, float x, float y, float size, const sf::Color& color, sf::Text& text, bool mono=false);

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -52,9 +52,9 @@ public:
   sf::Music& GetCurMusic() const;
   void StopAllMusic();
 
-  void StartNewGame();
+  void StartNewGame(bool moon_gravity, bool scale_marble);
   void StartNextLevel();
-  void StartSingle(int level);
+  void StartSingle(int level, bool moon_gravity, bool scale_marble);
   void ResetLevel();
 
   void UpdateMarble(float dx=0.0f, float dy=0.0f);


### PR DESCRIPTION
After all levels has been completed two new toggles show up in the main menu: "Moon Gravity" and "Scroll scales marble". 

The first makes the gravity 6 times weaker. 
The second makes it such that the scroll wheel changes the size of the marble, instead of zooming in. 
Because of how the physics are implemented it seems like the entire world grows/shrinks around you.

If any of the toggles are enabled, no new highscores will be recorded. 

I'm not exactly fluent in C++, so I'm sure it could have been done in a nicer way. 