### PR TITLE
Add support for certain Intel GPUs

### DIFF
--- a/assets/vert.glsl
+++ b/assets/vert.glsl
@@ -17,6 +17,6 @@
 #version 120
 uniform vec2 iResolution;
 void main() {
-  vec2 pos = (gl_Vertex.xy / iResolution) * 2.0 - vec2(1, 1);
+  vec2 pos = (gl_Vertex.xy / iResolution) * 2.0 - vec2(1.0, 1.0);
   gl_Position = vec4(pos, 0.0, 1.0);
 }


### PR DESCRIPTION
Some GPUs, for example the Intel GPUs built into most MacBook models, don't support specifying floating-point values with integers in GLSL shaders. Therefore, the constant `1` in the context of a `vec2` must be changed to `1.0` to make the vertex shader compile on these GPUs.

I had this issue on my Late 2013 MacBook Pro with the Built-in Intel Iris GPU. This small modification fixed the issue of the vertex shader not compiling on my system.

This should resolve issue #20.