### PR TITLE
Ray marching performance patch

### DIFF
--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -221,9 +221,9 @@ vec4 ray_march(inout vec4 p, vec4 ray, float sharpness) {
 	float min_d = 1.0;
 	for (; s < MAX_MARCHES; s += 1.0) {
 		//if the distance from the surface is less than the distance per pixel we stop
-		if (abs(d) < FOVperPixel*td) {
-			s += 0.14*d / FOVperPixel*td;
-			break;
+		float min_dist = min(FOVperPixel*td, MIN_DIST);
+		if (abs(d) < min_dist ) {
+   		        s += 0.14*d / min_dist ;
 		} else if (td > MAX_DIST) {
 			break;
 		}

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -222,7 +222,7 @@ vec4 ray_march(inout vec4 p, vec4 ray, float sharpness) {
 	for (; s < MAX_MARCHES; s += 1.0) {
 		//if the distance from the surface is less than the distance per pixel we stop
 		float min_dist = min(FOVperPixel*td, MIN_DIST);
-		if (abs(d) < min_dist ) {
+		if (d < min_dist ) {
    		        s += 0.14*d / min_dist ;
 			break;
 		} else if (td > MAX_DIST) {

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -221,7 +221,7 @@ vec4 ray_march(inout vec4 p, vec4 ray, float sharpness) {
 	float min_d = 1.0;
 	for (; s < MAX_MARCHES; s += 1.0) {
 		//if the distance from the surface is less than the distance per pixel we stop
-		float min_dist = min(FOVperPixel*td, MIN_DIST);
+		float min_dist = max(FOVperPixel*td, MIN_DIST);
 		if (d < min_dist ) {
    		        s += 0.14*d / min_dist ;
 			break;

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -132,7 +132,7 @@ float de_capsule(vec4 p, float h, float r) {
 //   Main DEs
 //##########################################
 float de_fractal(vec4 p) {
-  for (int i = 0; i < 16; ++i) {
+  for (int i = 0; i < FRACTAL_ITER; ++i) {
     p.xyz = abs(p.xyz);
     rotZ(p, iFracAng1);
     mengerFold(p);
@@ -144,7 +144,7 @@ float de_fractal(vec4 p) {
 }
 vec4 col_fractal(vec4 p) {
   vec3 orbit = vec3(0.0);
-  for (int i = 0; i < 16; ++i) {
+  for (int i = 0; i < FRACTAL_ITER; ++i) {
     p.xyz = abs(p.xyz);
     rotZ(p, iFracAng1);
     mengerFold(p);

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -40,7 +40,7 @@
 #define SUN_SHARPNESS 2.0
 #define SUN_SIZE 0.004
 #define VIGNETTE_STRENGTH 0.5
-#define FRACTAL_ITER 14
+#define FRACTAL_ITER 16
 #define ENABLE_FILTERING 1
 
 uniform mat4 iMat;

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -246,7 +246,8 @@ vec4 scene(inout vec4 p, inout vec4 ray, float vignette) {
 	//Determine the color for this pixel
 	vec4 col = vec4(0.0);
 	
-	if (d < td*FOVperPixel) {
+	float min_dist = max(FOVperPixel*td, MIN_DIST);
+	if (d < min_dist) {
 		//Get the surface normal
 		vec4 grad = calcGrad(p,td*FOVperPixel*0.2);
 		vec3 n = normalize(grad.xyz);

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -252,6 +252,8 @@ vec4 scene(inout vec4 p, inout vec4 ray, float vignette) {
 		
 		//find closest surface point, without this we get weird coloring artifacts
 		p.xyz -= n*d;
+		
+		vec3 reflected = ray.xyz - 2.0*dot(ray.xyz, n) * n;
 
 		//Get coloring
 		vec4 orig_col = clamp(COL(p), 0.0, 1.0);

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -210,15 +210,15 @@ vec4 calcGrad(vec4 p, float dx)
 	    k.xxxx*DE(p + k.xxxz*dx)) / vec4(4*dx,4*dx,4*dx,4);
 }
 
-//find the average color of the fractal in a radius dx
-vec4 smoothColor(vec4 p, float dx)
+//find the average color of the fractal in a radius dx in plane s1-s2
+vec4 smoothColor(vec4 p, vec3 s1, vec3 s2, float dx)
 {
-	const vec3 k = vec3(1,-1,0);
-    return (COL(p + k.xyyz*dx) + 
-			COL(p + k.yyxz*dx) + 
-			COL(p + k.yxyz*dx) + 
-			COL(p + k.xxxz*dx))/4;
+    return (COL(p + vec4(s1,0)*dx) + 
+			COL(p - vec4(s1,0)*dx) + 
+			COL(p + vec4(s2,0)*dx) + 
+			COL(p - vec4(s2,0)*dx))/4;
 }
+
 
 vec4 ray_march(inout vec4 p, vec4 ray, float sharpness) {
 	//March the ray
@@ -269,7 +269,12 @@ vec4 scene(inout vec4 p, inout vec4 ray, float vignette) {
 		
 		//Get coloring
 		#if ENABLE_FILTERING
-			vec4 orig_col = clamp(smoothColor(p, min_dist*0.5), 0.0, 1.0);
+			//sample direction 1, the cross product between the ray and the surface normal, should be parallel to the surface
+			vec3 s1 = normalize(cross(ray.xyz,n));
+			//sample direction 2, the cross product between s1 and the surface normal
+			vec3 s2 = cross(s1,n);
+			//get filtered color
+			vec4 orig_col = clamp(smoothColor(p, s1, s2, min_dist*0.5), 0.0, 1.0);
 		#else 
 			vec4 orig_col = clamp(COL(p), 0.0, 1.0);
 		#endif

--- a/assets/frag.glsl
+++ b/assets/frag.glsl
@@ -224,6 +224,7 @@ vec4 ray_march(inout vec4 p, vec4 ray, float sharpness) {
 		float min_dist = min(FOVperPixel*td, MIN_DIST);
 		if (abs(d) < min_dist ) {
    		        s += 0.14*d / min_dist ;
+			break;
 		} else if (td > MAX_DIST) {
 			break;
 		}


### PR DESCRIPTION
The main change is in the "ray has hit the surface" condition, I modified it, so the marching stops when the ray is closer then the visible distance per pixel from the camera at this position. Since we march far less steps it gives quite a considerable performance boost. In my case it was about 20-100% more fps, depending on the distance from the fractal. It didn't work by itself though, since it gave some weird graphical artifacts, the problem was in the fact that the point was too far from the fractal surface, so I added an additional step to march in the opposite direction of the surface normal to get to the closest surface point. (Actually, isn't it simpler to find the collisions between the marble and the fractal in this way?)  
Also I added a faster numerical normal function, it uses 4 DE calculations instead of 6, credit to Inigo Quilez.

Before the change:
![before](https://user-images.githubusercontent.com/47035925/52313466-4aab3900-29b7-11e9-884e-a3523ec786a7.PNG)

After:
![after](https://user-images.githubusercontent.com/47035925/52313493-63b3ea00-29b7-11e9-9950-af61bb4a191f.PNG)

Since I'm a proud owner of a potato GPU Nvidia 730GT, this really helps =)
