### PR TITLE
cmake: Use encapsulated + transitive target linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,16 @@ find_package(SFML 2.5 COMPONENTS system window graphics audio REQUIRED)
 
 ## TARGETS
 
+set(MarbleMarcherDepTargets
+  sfml-system
+  sfml-window
+  sfml-graphics
+  sfml-audio
+)
+
 add_subdirectory(src)
 target_include_directories(MarbleMarcherSources PUBLIC
   ${EIGEN3_INCLUDE_DIR}
-  ${SFML_INCLUDE_DIR}
 )
 target_compile_definitions(MarbleMarcherSources PRIVATE SFML_STATIC)
 
@@ -25,8 +31,4 @@ endif()
 target_compile_definitions(MarbleMarcher PRIVATE SFML_STATIC)
 target_link_libraries(MarbleMarcher
   MarbleMarcherSources
-  sfml-system
-  sfml-window
-  sfml-graphics
-  sfml-audio
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,3 +12,6 @@ add_library(MarbleMarcherSources
   SelectRes.h
   Settings.h
 )
+target_link_libraries(MarbleMarcherSources
+  ${MarbleMarcherDepTargets}
+)


### PR DESCRIPTION
I believe this might be one way to Resolve #6

My steps for compiling on Ubuntu 18.04:
```sh
# Prereqs: Mebbe some others needed.
sudo apt install libfreetype6-dev libx11-dev libxrandr-dev libudev-dev libflac-dev libogg-dev libvorbis-dev libopenal-dev

# Build SFML from source, install to local place.
git clone https://github.com/SFML/SFML.git 2.5.1
( set -eux;
  cd SFML
  mkdir build && cd build
  cmake .. -DCMAKE_INSTALL_PREFIX=~./local/opt/sfml/2.5.1
  make -j  X install
)

# Build this project.
git clone https://github.com/HackerPoet/MarbleMarcher
cd MarbleMarcher
( set -eux;
  mkdir build && cd build
  cmake .. -DCMAKE_PREFIX_PATH=~./local/opt/sfml/2.5.1
  make -j X
)

# Enjoy the psychadelics :)
./build/MarbleMarger
# ... and get lost in Hole-in-One :P
```
